### PR TITLE
Add option to ignore general error

### DIFF
--- a/custom_components/hiq/sensor.py
+++ b/custom_components/hiq/sensor.py
@@ -347,8 +347,8 @@ def find_power_meter(
                 is_ok = _is_power_meter_ok(coordinator, key)
                 if is_ok or add_all:
                     fact = 1.0
-                    val = coordinator.data.vars.get(key, 0)
-                    if val > 300:
+                    val = coordinator.data.vars.get(key, None)
+                    if val is not None and val.value > 300:
                         fact = 0.1
                     res.append(
                         HiqSensorEntity(

--- a/custom_components/hiq/strings.json
+++ b/custom_components/hiq/strings.json
@@ -20,6 +20,15 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "scgi_server_not_running": "scgi server is not running",
       "plc_not_existing": "PLC with address `{address}` does not exist"
+    },
+    "options": {
+      "step": {
+        "init": {
+          "data": {
+            "ignore_general_error": "Ignore general_error from expansion unit (if checked, all found devices will be add to home assistant, use at your own risk)"
+          }
+        }
+      }
     }
   }
 }

--- a/custom_components/hiq/strings.json
+++ b/custom_components/hiq/strings.json
@@ -20,15 +20,6 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "scgi_server_not_running": "scgi server is not running",
       "plc_not_existing": "PLC with address `{address}` does not exist"
-    },
-    "options": {
-      "step": {
-        "init": {
-          "data": {
-            "ignore_general_error": "Ignore general_error from expansion unit (if checked, all found devices will be add to home assistant, use at your own risk)"
-          }
-        }
-      }
     }
   }
 }

--- a/custom_components/hiq/translations/en.json
+++ b/custom_components/hiq/translations/en.json
@@ -21,5 +21,14 @@
         "description": "Set up your HIQ-Home control to integrate with Home Assistant."
       }
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "ignore_general_error": "Ignore general_error from expansion unit (if checked, all found devices will be add to home assistant, use at your own risk)"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
A new option to ignore general error from expansion units.
By default only active devices will be added to home assistant.