### PR TITLE
Add via_device on sub devices

### DIFF
--- a/custom_components/hiq/cover.py
+++ b/custom_components/hiq/cover.py
@@ -67,6 +67,7 @@ def find_blinds(
                     entry_type=None,
                     sw_version=DEVICE_SW_VERSION,
                     hw_version=DEVICE_HW_VERSION,
+                    via_device=(DOMAIN, coordinator.cybro.nad),
                 )
                 var_sp = _get_blind_var(coordinator, key, 0)
                 var_up = _get_blind_var(coordinator, key, 1)

--- a/custom_components/hiq/light.py
+++ b/custom_components/hiq/light.py
@@ -90,6 +90,7 @@ def find_on_off_lights(
                     entry_type=None,
                     sw_version=DEVICE_SW_VERSION,
                     hw_version=DEVICE_HW_VERSION,
+                    via_device=(DOMAIN, coordinator.cybro.nad),
                 )
 
                 res.append(HiqUpdateLight(coordinator, key, dev_info=dev_info))
@@ -148,6 +149,7 @@ def find_dimm_lights(
                     entry_type=None,
                     sw_version=DEVICE_SW_VERSION,
                     hw_version=DEVICE_HW_VERSION,
+                    via_device=(DOMAIN, coordinator.cybro.nad),
                 )
                 res.append(
                     HiqUpdateLight(

--- a/custom_components/hiq/sensor.py
+++ b/custom_components/hiq/sensor.py
@@ -206,6 +206,7 @@ def find_temperatures(
         entry_type=None,
         sw_version=DEVICE_SW_VERSION,
         hw_version=DEVICE_HW_VERSION,
+        via_device=(DOMAIN, coordinator.cybro.nad),
     )
 
     for key in coordinator.data.plc_info.plc_vars:
@@ -272,6 +273,7 @@ def find_weather(
         entry_type=None,
         sw_version=DEVICE_SW_VERSION,
         hw_version=DEVICE_HW_VERSION,
+        via_device=(DOMAIN, coordinator.cybro.nad),
     )
 
     for key in coordinator.data.plc_info.plc_vars:
@@ -348,6 +350,7 @@ def find_power_meter(
         entry_type=None,
         sw_version=DEVICE_SW_VERSION,
         hw_version=DEVICE_HW_VERSION,
+        via_device=(DOMAIN, coordinator.cybro.nad),
     )
     for key in coordinator.data.plc_info.plc_vars:
         if key.find(var_prefix) != -1:

--- a/custom_components/hiq/weather.py
+++ b/custom_components/hiq/weather.py
@@ -69,6 +69,7 @@ async def async_setup_entry(
             entry_type=None,
             sw_version=DEVICE_SW_VERSION,
             hw_version=DEVICE_HW_VERSION,
+            via_device=(DOMAIN, coordinator.cybro.nad),
         )
 
         async_add_entities([HiqWeatherEntity(var_prefix, coordinator, dev_info)])


### PR DESCRIPTION
Add
`via_device=(DOMAIN, coordinator.cybro.nad),`
on every sub device (eg: Light, Blind, Temperatures, ..)