### PR TITLE
Bump cybro to 0.1.2

### DIFF
--- a/custom_components/hiq/manifest.json
+++ b/custom_components/hiq/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/killer0071234/ha-hiq",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/killer0071234/ha-hiq/issues",
-  "requirements": ["cybro==0.1.0", "xmltodict==0.13.0"],
+  "requirements": ["cybro==0.1.2", "xmltodict==0.13.0"],
   "version": "0.0.10"
 }


### PR DESCRIPTION
Changelog of dependency: https://github.com/killer0071234/python-cybro/compare/v0.1.0...v0.1.2
Fix catching a non BaseException in cybro python library