### PR TITLE
Faster scan interval when using the addon

### DIFF
--- a/custom_components/hiq/config_flow.py
+++ b/custom_components/hiq/config_flow.py
@@ -18,6 +18,8 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_IGNORE_GENERAL_ERROR
+from .const import DEFAULT_HOST
+from .const import DEFAULT_PORT
 from .const import DOMAIN
 from .const import LOGGER
 
@@ -84,8 +86,8 @@ class HiqFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_HOST, default="85493909-cybroscgiserver"): str,
-                    vol.Required(CONF_PORT, default=4000): int,
+                    vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
+                    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
                     vol.Required(CONF_ADDRESS, default=1000): int,
                     vol.Required(CONF_IGNORE_GENERAL_ERROR, default=False): bool,
                 }

--- a/custom_components/hiq/const.py
+++ b/custom_components/hiq/const.py
@@ -15,6 +15,10 @@ DEVICE_SW_VERSION = "0.2.0"
 
 LOGGER = logging.getLogger(__package__)
 SCAN_INTERVAL = timedelta(seconds=10)
+SCAN_INTERVAL_ADDON = timedelta(seconds=5)
+
+DEFAULT_HOST = "85493909-cybroscgiserver"
+DEFAULT_PORT = 4000
 
 # Options
 CONF_IGNORE_GENERAL_ERROR = "ignore_general_error"

--- a/custom_components/hiq/coordinator.py
+++ b/custom_components/hiq/coordinator.py
@@ -45,11 +45,20 @@ class HiqDataUpdateCoordinator(DataUpdateCoordinator[HiqDevice]):
         self.unique_id = "c" + str(entry.data[CONF_ADDRESS])
         self.unsub: Callable | None = None
 
+        update_interval = SCAN_INTERVAL
+        if entry.data[CONF_HOST] in (
+            DEFAULT_HOST,
+            "localhost",
+            "127.0.0.1",
+            "::1",
+        ):
+            update_interval = SCAN_INTERVAL_ADDON
+
         super().__init__(
             hass,
             LOGGER,
             name=DOMAIN,
-            update_interval=SCAN_INTERVAL_ADDON if entry.data[CONF_HOST] == DEFAULT_HOST else SCAN_INTERVAL,
+            update_interval=update_interval,
         )
 
     async def _async_update_data(self) -> HiqDevice:

--- a/custom_components/hiq/coordinator.py
+++ b/custom_components/hiq/coordinator.py
@@ -16,9 +16,11 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from .const import DEFAULT_HOST
 from .const import DOMAIN
 from .const import LOGGER
 from .const import SCAN_INTERVAL
+from .const import SCAN_INTERVAL_ADDON
 
 
 class HiqDataUpdateCoordinator(DataUpdateCoordinator[HiqDevice]):
@@ -47,7 +49,7 @@ class HiqDataUpdateCoordinator(DataUpdateCoordinator[HiqDevice]):
             hass,
             LOGGER,
             name=DOMAIN,
-            update_interval=SCAN_INTERVAL,
+            update_interval=SCAN_INTERVAL_ADDON if entry.data[CONF_HOST] == DEFAULT_HOST else SCAN_INTERVAL,
         )
 
     async def _async_update_data(self) -> HiqDevice:


### PR DESCRIPTION
When using the cybro scgi server addon, a smaller scan interval of 5 seconds is used.
at using a external scgi server the existing 10 seconds interval is used.